### PR TITLE
changed classes/defs to match PEP8 naming conventions, used anaconda …

### DIFF
--- a/setlistfm/getsetlist.py
+++ b/setlistfm/getsetlist.py
@@ -1,33 +1,37 @@
-# 
+#
 # Created By Cameron Krusemark
 # Created 11/8/2015
+import json
+import requests
 
-class setlist:
-    def getSetlistByArtist(self, artist):
-        import json, requests
 
-        # Get method parameter and build web service URL   
-        #self.artist = artist  
-        url = "http://api.setlist.fm/rest/0.1/search/setlists.json?artistName="+artist
-        
+class Setlist:
+
+    def get_setlist_by_artist(self, artist):
+
+        # Get method parameter and build web service URL
+        #self.artist = artist
+        url = "http://api.setlist.fm/rest/0.1/search/setlists.json?artistName=" + \
+            artist
+
         # Call Setlist.fm API using requests library
         resp = requests.get(url)
-        
+
         # Format Request into JSON Object
         self.data = json.loads(resp.text)
-        
-    def getSetlistByArtistMbid(self, artistMbid):
-        import json, requests
 
-        # Get method parameter and build web service URL     
-        url = "http://api.setlist.fm/rest/0.1/search/setlists.json?artistMbid="+artistMbid
-        
+    def get_setlist_by_artist_mbid(self, artistMbid):
+
+        # Get method parameter and build web service URL
+        url = "http://api.setlist.fm/rest/0.1/search/setlists.json?artistMbid=" + \
+            artistMbid
+
         # Call Setlist.fm API using requests library
         resp = requests.get(url)
-        
+
         # Format Request into JSON Object
         self.data = json.loads(resp.text)
-    
+
 ####################################################
 # Below will be moved into the processing package
 
@@ -35,7 +39,7 @@ class setlist:
 objSetlistbyArtist = setlist()
 
 # Call Method from Object
-objSetlistbyArtist.getSetlistByArtist('Metallica')
+objSetlistbyArtist.get_setlist_by_artist('Metallica')
 
 # Print JSON
 print objSetlistbyArtist.data
@@ -43,9 +47,6 @@ print objSetlistbyArtist.data
 
 # Example 2
 objSetlistByArtistMbid = setlist()
-objSetlistByArtistMbid.getSetlistByArtistMbid('a16e47f5-aa54-47fe-87e4-bb8af91a9fdd')
+objSetlistByArtistMbid.get_setlist_by_artist_mbid(
+    'a16e47f5-aa54-47fe-87e4-bb8af91a9fdd')
 print objSetlistByArtistMbid.data
-
-
-
-


### PR DESCRIPTION
…PEP8 linter to autoformat

Using sublime text 3 code linting (https://packagecontrol.io/packages/Python%20PEP8%20Autoformat) autormatted, changed def names and class name to match PEP8 style guide (https://www.python.org/dev/peps/pep-0008/#class-names)
